### PR TITLE
Add envs and secrets to the artifact inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Artifacts can be created two ways using this provisioner: using OpenTofu `output
 
 ### OpenTofu Outputs
 
-After every provision, this provider will scan the module directory for files matching the pattern `artifact_<name>.jq`. If a file matching this pattern is present, it will be used as a JQ template to render and publish a Massdriver artifact. The inputs to the JQ template will be a JSON object with the params, connections and module outputs as top level fields.
+After every provision, this provider will scan the module directory for files matching the pattern `artifact_<name>.jq`. If a file matching this pattern is present, it will be used as a JQ template to render and publish a Massdriver artifact. The inputs to the JQ template will be a JSON object with the params, connections, envs, secrets and module outputs as top level fields.
 
 ```json
 {
@@ -48,6 +48,12 @@ After every provision, this provider will scan the module directory for files ma
         ...
     },
     "connections": {
+        ...
+    },
+    "envs": {
+        ...
+    },
+    "secrets": {
         ...
     },
     "outputs": {
@@ -126,6 +132,8 @@ In this case, the input to the `artifact_bucket.jq` template file would be:
             }
         }
     },
+    "envs": {},
+    "secrets": {},
     "outputs": {
         "artifact_bucket": {
             "data": {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -104,7 +104,7 @@ tofu apply $tf_flags tf.plan
 case "$MASSDRIVER_DEPLOYMENT_ACTION" in
     provision )
         tofu show -json  | jq '.values.outputs // {}' > outputs.json
-        jq -s '{params:.[0],connections:.[1],outputs:.[2]}' "$params_path" "$connections_path" outputs.json > artifact_inputs.json
+        jq -s '{params:.[0],connections:.[1],envs:.[2],secrets:.[3],outputs:.[4]}' "$params_path" "$connections_path" "$envs_path" "$secrets_path" outputs.json > artifact_inputs.json
         for artifact_file in artifact_*.jq; do
             [ -f "$artifact_file" ] || break
             field=$(echo "$artifact_file" | sed 's/^artifact_\(.*\).jq$/\1/')


### PR DESCRIPTION
Same update that was made to the helm provisioner: adding `envs` and `secrets` to the input to the artifacts jq template.