### PR TITLE
update xo artifact delete command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -138,7 +138,7 @@ case "$MASSDRIVER_DEPLOYMENT_ACTION" in
             [ -f "$artifact_file" ] || break
             field=$(echo "$artifact_file" | sed 's/^artifact_\(.*\).jq$/\1/')
             echo "Deleting artifact for field $field"
-            xo artifact delete -d "$field" -n "Artifact $field for $name_prefix"
+            xo artifact delete -d "$field"
         done
         ;;
 esac


### PR DESCRIPTION
* `xo artifact delete` no longer needs the name parameter.